### PR TITLE
[#154] 젠킨스파일의 도커 명령어 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -414,7 +414,7 @@ docker rm -f ${TEST_APP_NAME} || true
 
 cd /home/sw_team_3/backend
 
-docker compose -p sw_team_3 up -d app-local-1
+docker compose -p sw_team_3 up -d
 
 # 5) 상태 확인
 docker ps --filter "name=${TEST_APP_NAME}"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #154 

## 📝작업 내용

> 온프레미스 서버 배포 오류 해결을 위한 젠킨스파일의 도커 명령어 수정

- 젠킨스에 들어있는 도커 컴포즈는 최신 버전 형식인 `docker compose`를 사용하지만, 호스트의 도커가 재설치된 이후 `docker-compose`를 사용해 배포 시 오류가 발생했습니다.
- 원래는 도커 컴포즈의 목표 서버만을 재시작했지만, 불가피하기도 하고, 온프레미스 서버는 테스트만을 위한 용도기 때문에 한번에 컴포즈 구성요소를 모두 run하도록 수정했습니다.
