### PR TITLE
[#159] core 회원 가입 실패 시 방어 로직 추가

### DIFF
--- a/src/main/java/dev/syntax/domain/auth/service/SignupServiceImpl.java
+++ b/src/main/java/dev/syntax/domain/auth/service/SignupServiceImpl.java
@@ -65,7 +65,7 @@ public class SignupServiceImpl implements SignupService {
 			}
 			log.info("회원가입 + Core 회원 생성 완료: channelUserId={}, coreUserId={}",
 				user.getId(), user.getCoreUserId());
-		} catch (BusinessException e) {
+		} catch (RuntimeException  e) {
 			log.error("Core 회원 생성 실패: {}", e.getMessage(), e);
 			throw new BusinessException(ErrorAuthCode.CORE_INIT_FAIL);
 		}

--- a/src/main/java/dev/syntax/global/response/error/ErrorAuthCode.java
+++ b/src/main/java/dev/syntax/global/response/error/ErrorAuthCode.java
@@ -56,7 +56,7 @@ public enum ErrorAuthCode implements ErrorBaseCodeForErrorCode {
 	EMAIL_CONFLICT(HttpStatus.CONFLICT, "해당 이메일로 가입할 수 없습니다.", "AUTH03"),
 	KAKAO_EMAIL_CONFLICT(HttpStatus.CONFLICT, "해당 이메일로 가입된 카카오 계정이 있습니다.", "KAKAO02"),
 	KAKAO_PROVIDER_CONFLICT(HttpStatus.CONFLICT, "이미 등록된 회원입니다.", "KAKAO03"),
-	CORE_INIT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", "AUTH06");
+	CORE_INIT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "회원가입 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", "AUTH07");
 
 	// 마지막 항목의 ;을 쉼표로 바꾸고 여기에 마저 추가
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #159 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 회원가입 로직 안정화 및 Core 초기화 예외 처리 추가