### PR TITLE
[#206] 목표 계좌 생성 시 CORE에 삭제 요청 대신 조회 요청하도록 수정 

### DIFF
--- a/src/main/java/dev/syntax/domain/goal/service/GoalAccountServiceImpl.java
+++ b/src/main/java/dev/syntax/domain/goal/service/GoalAccountServiceImpl.java
@@ -189,14 +189,16 @@ public class GoalAccountServiceImpl implements GoalAccountService {
 				} catch (Exception retryException) {
 					log.error("[CHANNEL] 채널 DB 재등록 실패. Core 자동이체 롤백 시도. autoTransferId={}",
 						transferRes.autoTransferId(), retryException);
+
 					coreAutoTransferClient.deleteAutoTransfer(transferRes.autoTransferId());
-					throw retryException;
+
+					throw new BusinessException(ErrorBaseCode.AUTO_TRANSFER_SAVE_FAILED);
 				}
 			} else {
 				log.warn("[CORE] Core에 계좌 미존재. Core 자동이체 롤백 시도. autoTransferId={}",
 					transferRes.autoTransferId());
 				coreAutoTransferClient.deleteAutoTransfer(transferRes.autoTransferId());
-				throw e;
+				throw new BusinessException(ErrorBaseCode.AUTO_TRANSFER_SAVE_FAILED);
 			}
 		}
 	}

--- a/src/main/java/dev/syntax/global/response/error/ErrorBaseCode.java
+++ b/src/main/java/dev/syntax/global/response/error/ErrorBaseCode.java
@@ -134,6 +134,7 @@ public enum ErrorBaseCode implements ErrorCode {
 	AUTO_TRANSFER_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "자동이체 수정에 실패했습니다."),
 	AUTO_TRANSFER_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "자동이체 삭제에 실패했습니다."),
 	SSE_CONNECT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "초기 SSE 연결 이벤트 전송에 실패했습니다."),
+	AUTO_TRANSFER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "자동이체 정보 저장에 실패했습니다."),
 
 	/**
 	 * 카카오 로그인 관련 에러


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #206

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- **기존 로직**
```
Channel DB 자동이체 저장 실패 
→ 즉시 Core 자동이체 삭제 
→ 예외 발생
```
- **변경 후 로직**
```
Channel DB 자동이체 저장 실패 
→ Core에 계좌 존재 여부 조회 (verifyAccountExistsInCore)
→ 존재하면: Channel DB 재등록 시도
   - 성공: 정상 처리
   - 실패: Core 자동이체 삭제 후 예외 발생
→ 존재하지 않으면: Core 자동이체 삭제 후 예외 발생
```
