### PR TITLE
[#226] 운영 서버에서 localhost에 접근하지 못하는 문제 해결

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,6 +225,7 @@ sudo docker run -d \
   -e TZ=Asia/Seoul \
   --restart unless-stopped \
   -e SPRING_PROFILES_ACTIVE=secret \
+  --network host \
   -v /home/ubuntu/app-config/application-secret.yml:/config/application-secret.yml \
   teenyfinny/channel:latest
 
@@ -328,6 +329,7 @@ sudo docker run -d \
   -e TZ=Asia/Seoul \
   --restart unless-stopped \
   -e SPRING_PROFILES_ACTIVE=secret \
+  --network host \
   -v /home/ubuntu/app-config/application-secret.yml:/config/application-secret.yml \
   teenyfinny/channel:latest
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #226 

## 📝작업 내용

> 운영서버에서 127.0.0.1에 접근을 못하던 문제 해결

- 도커 네트워크 설정을 통해 로컬호스트에 접속할 수 있도록 수정했습니다.
