### PR TITLE
[#233] 목표통장 생성 시 core-channel 연동 수정

### DIFF
--- a/src/main/java/dev/syntax/domain/transfer/client/CoreAutoTransferClient.java
+++ b/src/main/java/dev/syntax/domain/transfer/client/CoreAutoTransferClient.java
@@ -1,15 +1,15 @@
 package dev.syntax.domain.transfer.client;
 
+import dev.syntax.domain.transfer.dto.CoreAllowanceUpdateAutoTransferReq;
+import dev.syntax.domain.transfer.dto.CoreCreateAutoTransferReq;
+import dev.syntax.domain.transfer.dto.CoreCreateAutoTransferRes;
+import dev.syntax.domain.transfer.dto.CoreGoalAutoTransferCreateReq;
+import dev.syntax.global.core.CoreApiProperties;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-
-import dev.syntax.domain.transfer.dto.CoreAllowanceUpdateAutoTransferReq;
-import dev.syntax.domain.transfer.dto.CoreCreateAutoTransferReq;
-import dev.syntax.domain.transfer.dto.CoreCreateAutoTransferRes;
-import dev.syntax.global.core.CoreApiProperties;
-import lombok.RequiredArgsConstructor;
 
 /**
  * Core 뱅킹 서버의 자동이체 생성 API를 호출하는 클라이언트입니다.
@@ -59,6 +59,22 @@ public class CoreAutoTransferClient {
         coreRestTemplate.delete(
                 properties.getBaseUrl() + DELETE_AUTO_TRANSFER_URL,
                 autoTransferId
+        );
+    }
+
+    private static final String GOAL_AUTO_TRANSFER_CREATE_URL = "/core/banking/auto-transfer/goal-by-user";
+
+    /**
+     * Core 목표 자동이체 생성 요청
+     *
+     * @param req 목표 자동이체 생성 요청 정보
+     * @return CoreAutoTransferRes (autoTransferId)
+     */
+    public CoreCreateAutoTransferRes createGoalAutoTransfer(CoreGoalAutoTransferCreateReq req) {
+        return coreRestTemplate.postForObject(
+                properties.getBaseUrl() + GOAL_AUTO_TRANSFER_CREATE_URL,
+                req,
+                CoreCreateAutoTransferRes.class
         );
     }
 }

--- a/src/main/java/dev/syntax/domain/transfer/dto/CoreGoalAutoTransferCreateReq.java
+++ b/src/main/java/dev/syntax/domain/transfer/dto/CoreGoalAutoTransferCreateReq.java
@@ -1,0 +1,24 @@
+package dev.syntax.domain.transfer.dto;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+/**
+ * Core 목표 자동이체 생성 요청 DTO.
+ *
+ * <p>
+ * 부모가 자녀의 목표 계좌로 자동이체를 등록할 때 사용됩니다.
+ * </p>
+ *
+ * @param childCoreId 자녀 CoreUser ID
+ * @param amount      이체 금액
+ * @param transferDay 매월 실행일
+ */
+@Builder
+public record CoreGoalAutoTransferCreateReq(
+        Long childCoreId,
+        BigDecimal amount,
+        Integer transferDay
+) {
+}

--- a/src/main/java/dev/syntax/domain/transfer/dto/CoreGoalAutoTransferCreateReq.java
+++ b/src/main/java/dev/syntax/domain/transfer/dto/CoreGoalAutoTransferCreateReq.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
  * Core 목표 자동이체 생성 요청 DTO.
  *
  * <p>
- * 부모가 자녀의 목표 계좌로 자동이체를 등록할 때 사용됩니다.
+ * 부모가 자녀의 용돈 계좌에서 자녀의 목표 계좌로 자동 이체를 생성할 때 사용됩니다.
  * </p>
  *
  * @param childCoreId 자녀 CoreUser ID


### PR DESCRIPTION
## #️⃣연관된 이슈

> closed #233 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 목표통장 생성 시 core-channel 연동 수정

- `CoreGoalAutoTransferCreateReq(childCoreId, amount, transferDay)`
- `CoreAutoTransferClient.createGoalAutoTransfer(...)`
→ Core의 /core/banking/auto-transfer/goal-by-user 호출
- 목표 계좌 생성 시 자동이체 연동 방식 변경
  - GoalAccountServiceImpl 에서 더 이상 fromAccountId/toAccountId 로 Core 계좌 PK를 넘기지 않음
  - 대신 자녀의 coreUserId + monthlyAmount + payDay 만 Core에 전달
  - Core가 자녀의 ALLOWANCE → ACTIVE GOAL 계좌를 직접 조회해 자동이체 생성하도록 위임