### PR TITLE
[#237] summary_report 테이블에 year 필드 추가

### DIFF
--- a/src/main/resources/DDL/schema.sql
+++ b/src/main/resources/DDL/schema.sql
@@ -197,6 +197,7 @@ create table if not exists summary_report
     primary key,
     created_at         datetime(6)    not null,
     month              int            not null,
+    year               int            not null,
     prev_total_expense decimal(12, 2) null,
     total_expense      decimal(12, 2) not null,
     user_id            bigint         not null,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) closed #237

## 📝작업 내용

> 리포트를 최근 1년 간 조회를 통해 저장됨에 따라 month로만 구분할 수 없어짐
> int year not null 필드 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
test db에는 이미 반영 완료
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
